### PR TITLE
BE 히스토리의 status 사용가능하게 수정

### DIFF
--- a/Server/src/main/java/com/branch/sikgu/meal/history/entity/History.java
+++ b/Server/src/main/java/com/branch/sikgu/meal/history/entity/History.java
@@ -3,9 +3,11 @@ package com.branch.sikgu.meal.history.entity;
 import com.branch.sikgu.meal.board.entity.Board;
 import com.branch.sikgu.member.entity.Member;
 import com.branch.sikgu.review.entity.Review;
+import com.branch.sikgu.review.repository.ReviewRepository;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.persistence.*;
@@ -20,7 +22,6 @@ import java.util.List;
 @Component
 //@EnableJpaAuditing
 public class History {
-
     // 식사이력 식별자
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,6 +45,8 @@ public class History {
 
     @Column(name = "status")
     private boolean status = false;
+
+
 
 //    @Column(name = "status")
 //    @Enumerated(EnumType.STRING)

--- a/Server/src/main/java/com/branch/sikgu/review/entity/Review.java
+++ b/Server/src/main/java/com/branch/sikgu/review/entity/Review.java
@@ -41,5 +41,21 @@ public class Review {
     @Column(name = "created_at")
     private LocalDateTime createdAt = LocalDateTime.now();
 
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private ReviewStatus status = ReviewStatus.REVIEW_PENDING;
+
+    public enum ReviewStatus {
+        REVIEW_PENDING("리뷰 제출 전"),
+        REVIEW_SUBMITTED("리뷰 제출 완료");
+
+        @Getter
+        private String status;
+
+        ReviewStatus(String status) {
+            this.status = status;
+        }
+    }
+
     // 추가적인 필드들...
 }

--- a/Server/src/main/java/com/branch/sikgu/review/repository/ReviewRepository.java
+++ b/Server/src/main/java/com/branch/sikgu/review/repository/ReviewRepository.java
@@ -1,5 +1,7 @@
 package com.branch.sikgu.review.repository;
 
+import com.branch.sikgu.meal.history.entity.History;
+import com.branch.sikgu.member.entity.Member;
 import com.branch.sikgu.review.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +11,6 @@ import java.util.List;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findByTargetMember_MemberIdOrderByCreatedAtDesc(Long myPageId);
+
+    Review findByReviewerAndTargetMemberAndHistory(Member currentUser, Member targetMember, History history);
 }

--- a/Server/src/main/java/com/branch/sikgu/review/service/ReviewService.java
+++ b/Server/src/main/java/com/branch/sikgu/review/service/ReviewService.java
@@ -36,24 +36,30 @@ public class ReviewService {
                 .orElseThrow(() -> new EntityNotFoundException("History not found with id: " + historyId));
 
         // 현재 요청을 보낸 사용자 정보 가져오기
-        Member currentUser = memberService.findVerifiedMember(memberService.getCurrentMemberId(authentication));
+        Member currentMember = memberService.findVerifiedMember(memberService.getCurrentMemberId(authentication));
         Member targetMember = memberService. findVerifiedMember(memberId);
 
 
         // 1, 2 검증
         isReviewExistsForUser(historyId, memberId, authentication);
-        validateCurrentUserIsMember(history, currentUser);
+        validateCurrentUserIsMember(history, currentMember);
             validateCurrentUserIsMember(history, targetMember);
 
         // History에 리뷰와 좋아요 추가
-        Review review = new Review();
+            Review review = reviewRepository.findByReviewerAndTargetMemberAndHistory(currentMember, targetMember, history);
             review.setContent(requestDto.getReviewContent());
             review.setLiked(requestDto.isLiked());
-            review.setReviewer(currentUser);
+            review.setReviewer(currentMember);
             review.setTargetMember(targetMember);
             review.setHistory(history);
+            review.setStatus(Review.ReviewStatus.REVIEW_SUBMITTED);
 
         history.getReviews().add(review);
+
+            // 모든 리뷰 작성 확인 및 History 상태 변경
+            if (checkAllReviewsSubmitted(history)) {
+                history.setStatus(true);
+            }
 
         // History 저장
         historyRepository.save(history);
@@ -65,15 +71,11 @@ public class ReviewService {
         History history = historyRepository.findById(historyId)
                 .orElseThrow(() -> new EntityNotFoundException("History not found with id: " + historyId));
         // 특정 멤버가 해당 History 내의 동일한 멤버에게 이미 리뷰를 남겼는지 확인 (이미 작성했다면 true)
-//        if (history.getReviews()
-//                .stream()
-//                .anyMatch(review -> review.getReviewer().getMemberId().equals(targetMemberId)))
-//        {
-//            throw new BusinessLogicException(ExceptionCode.DUPLICATE_REVIEW, HttpStatus.BAD_REQUEST);
-//        }
-        if (history.getReviews().stream()
+        boolean isDuplicateReview = history.getReviews().stream()
                 .filter(review -> review.getReviewer().getMemberId().equals(memberService.getCurrentMemberId(authentication)))
-                .anyMatch(review -> review.getTargetMember().getMemberId().equals(targetMemberId))) {
+                .filter(review -> review.getTargetMember().getMemberId().equals(targetMemberId))
+                .anyMatch(review -> review.getStatus() == Review.ReviewStatus.REVIEW_SUBMITTED);
+        if (isDuplicateReview) {
             throw new BusinessLogicException(ExceptionCode.DUPLICATE_REVIEW, HttpStatus.BAD_REQUEST);
         }
         // 본인에게는 리뷰할 수 없는 로직
@@ -87,8 +89,21 @@ public class ReviewService {
     public void validateCurrentUserIsMember(History history, Member member) {
         List<Member> members = history.getMembers();
         if (!members.contains(member)) {
-            throw new AccessDeniedException("Current user is not a member of the history");
+            throw new AccessDeniedException("현재 멤버는 히스토리의 멤버가 아닙니다.");
         }
+    }
+
+    // 모든 리뷰 작성 확인
+    private boolean checkAllReviewsSubmitted(History history) {
+        List<Review> reviews = history.getReviews();
+
+        // History 내의 모든 리뷰의 상태 확인
+        for (Review review : reviews) {
+            if (review.getStatus() != Review.ReviewStatus.REVIEW_SUBMITTED) {
+                return false; // 작성되지 않은 리뷰가 존재하면 false 반환
+            }
+        }
+        return true; // 모든 리뷰가 작성되었으면 true 반환
     }
 
 


### PR DESCRIPTION
## 📝 변경 사항

해당 히스토리의 리뷰가 모두 작성되었을 시 status가 true로 변경됩니다.
history 객체 생성 시 해당 history의 review 객체들도 같이 생성되게 수정...
(리뷰의 진행도를 확인하기 위해...)
객체를 미리 생성하는게 적절할 지 모르겠네요... 

## 📷 스크린샷 (선택 사항)

(스크린샷을 삽입해주세요.)

## 🧪 테스트 계획 (선택 사항)

(테스트 계획을 적어주세요.)

## 🐛 버그 (선택 사항)

(버그가 있으면 적어주세요.)

## 💡 아이디어 (선택 사항)

(추가적인 아이디어가 있으면 적어주세요.)

## 🔗 관련 링크 (선택 사항)

(관련 링크가 있다면 적어주세요.)

## 📌 체크리스트

- [ ] 코드 스타일을 준수하였습니다.
- [ ] 코드에 대한 문서화가 완료되었습니다.
- [ ] 테스트를 완료하였습니다.
- [ ] 변경 사항에 대한 리뷰어와 논의가 이루어졌습니다.
- [ ] 변경 사항이 마스터 브랜치와 충돌하지 않습니다.
